### PR TITLE
Use statement organization detection and autofixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 /composer.lock
 /.idea
 *.iml
+
+.buildpath
+.settings
+.project
+

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
 
     "require-dev": {
-        "phake/phake": "1.0.3",
+        "phake/phake": "v2.0.0-alpha2",
         "phpunit/phpunit": "3.7.21"
     },
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,6 @@
 <phpunit backupGlobals="true"
          backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
          cacheTokens="false"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/src/main/bugfree/ErrorType.php
+++ b/src/main/bugfree/ErrorType.php
@@ -15,6 +15,7 @@ class ErrorType
     const MULTI_STATEMENT_USE                   = 'multiStatementUse';
     const MISSING_NAMESPACE                     = 'missingNamespace';
     const UNUSED_USE                            = 'unusedUse';
+    const DISORGANIZED_USES                     = 'disorganizedUses';
 
     const WARNING = 'warning';
     const ERROR = 'error';

--- a/src/main/bugfree/cli/Lint.php
+++ b/src/main/bugfree/cli/Lint.php
@@ -135,7 +135,7 @@ class Lint extends Command
         return $this->lintFiles($basedir, $config, $formatter, $files);
     }
 
-    public function lintFiles($basedir, Config $config, OutputFormatter $formatter, array $files)
+    private function lintFiles($basedir, Config $config, OutputFormatter $formatter, array $files)
     {
         $bugfree = new Bugfree(new AutoloaderResolver($basedir), $config);
 

--- a/src/main/bugfree/config/EmitLevel.php
+++ b/src/main/bugfree/config/EmitLevel.php
@@ -17,8 +17,9 @@ class EmitLevel
     public $multiStatementUse = ErrorType::WARNING;
     public $missingNamespace = ErrorType::ERROR;
     public $unusedUse = ErrorType::WARNING;
+    public $disorganizedUses = ErrorType::WARNING;
 
-    public function __construct(array $values=[])
+    public function __construct(array $values = [])
     {
         foreach ($values as $key => $value) {
             $this->$key = $value;

--- a/src/main/bugfree/fix/AbstractFix.php
+++ b/src/main/bugfree/fix/AbstractFix.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace bugfree\fix;
+
+
+abstract class AbstractFix implements Fix
+{
+    /** @var int */
+    private $line;
+
+    /** @var string */
+    private $reason;
+
+    public function __construct($line, $reason)
+    {
+        $this->line = $line;
+        $this->reason = $reason;
+    }
+
+    public function getLine()
+    {
+        return $this->line;
+    }
+
+    abstract public function run(array &$fileLines);
+
+    public function getReason()
+    {
+        return $this->reason;
+    }
+}

--- a/src/main/bugfree/fix/RemoveLineFix.php
+++ b/src/main/bugfree/fix/RemoveLineFix.php
@@ -3,32 +3,10 @@
 namespace bugfree\fix;
 
 
-class RemoveLineFix implements Fix
+class RemoveLineFix extends AbstractFix
 {
-    /** @var int */
-    private $line;
-
-    /** @var string */
-    private $reason;
-
-    public function __construct($line, $reason)
-    {
-        $this->line = $line;
-        $this->reason = $reason;
-    }
-
-    public function getLine()
-    {
-        return $this->line;
-    }
-
     public function run(array &$fileLines)
     {
-        array_splice($fileLines, $this->line - 1, 1);
-    }
-
-    public function getReason()
-    {
-        return $this->reason;
+        array_splice($fileLines, $this->getLine() - 1, 1);
     }
 }

--- a/src/main/bugfree/fix/SwapLineFix.php
+++ b/src/main/bugfree/fix/SwapLineFix.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace bugfree\fix;
+
+
+class SwapLineFix extends AbstractFix
+{
+    /** @var int */
+    private $destinationLine;
+
+    public function __construct($sourceLine, $destinationLine, $reason)
+    {
+        parent::__construct($sourceLine, $reason);
+        $this->destinationLine = $destinationLine;
+    }
+
+    public function run(array &$fileLines)
+    {
+        $sourceIndex = $this->getLine() - 1;
+        $destinationIndex = $this->destinationLine - 1;
+
+        $sourceLine = $fileLines[$sourceIndex];
+        $destinationLine = $fileLines[$destinationIndex];
+
+        $fileLines[$sourceIndex] = $destinationLine;
+        $fileLines[$destinationIndex] = $sourceLine;
+    }
+}

--- a/src/main/bugfree/helper/UseStatementOrganizer.php
+++ b/src/main/bugfree/helper/UseStatementOrganizer.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace bugfree\helper;
+
+
+use PHPParser_Node_Stmt_UseUse as UseStatement;
+
+/**
+ * Checks if use statements are organized and determines what is required to
+ * organize them.
+ */
+class UseStatementOrganizer
+{
+    /** @var UseStatement[] */
+    private $useStatements = [];
+
+    /** @var UseStatement[] */
+    private $organizedUseStatements = [];
+
+    /** @var array */
+    private $lineNumberMapping = null;
+
+    /**
+     * @param UseStatement[] $useStatements An array of use statements in the order they are defined
+     */
+    public function __construct(array $useStatements)
+    {
+        $this->useStatements = $useStatements;
+        $this->organizedUseStatements = $this->getOrganizedUseStatements();
+    }
+
+    /**
+     * @return UseStatement[]
+     */
+    private function getOrganizedUseStatements()
+    {
+        $organizer = function (UseStatement $a, UseStatement $b) {
+            $aParts = $a->name->parts;
+            $aNumParts = count($aParts);
+            $bParts = $b->name->parts;
+            $bNumParts = count($bParts);
+            $numParts = min($aNumParts, $bNumParts);
+
+            $i = 0;
+
+            while ($i < $numParts) {
+                $aPart = $aParts[$i];
+                $bPart = $bParts[$i];
+
+                // sort \a\b\c\Class before \a\b\c\a\Class
+                $isLastAPart = $i == ($aNumParts - 1);
+                $isLastBPart = $i == ($bNumParts - 1);
+
+                if ($isLastAPart && !$isLastBPart) {
+                    return -1;
+                } elseif ($isLastBPart && !$isLastAPart) {
+                    return 1;
+                }
+
+                $comparison = strcasecmp($aPart, $bPart);
+
+                if ($comparison !== 0) {
+                    return $comparison;
+                }
+
+                $i++;
+            }
+
+            return 0;
+        };
+
+        // create a copy
+        $useStatements = $this->useStatements;
+
+        usort($useStatements, $organizer);
+
+        return $useStatements;
+    }
+
+    /**
+     * Returns true if the list of use statements are organized.
+     *
+     * @return boolean
+     */
+    public function areOrganized()
+    {
+        $current = $this->useStatementsToString($this->useStatements);
+        $organized = $this->useStatementsToString($this->organizedUseStatements);
+
+        return count(array_diff_assoc($current, $organized)) == 0;
+    }
+
+    /**
+     * @param UseStatement[] $useStatements
+     * @return array
+     */
+    private function useStatementsToString(array $useStatements)
+    {
+        $useStrings = [];
+
+        foreach ($useStatements as $useStatement) {
+            $useStrings[] = $useStatement->name->toString();
+        }
+
+        return $useStrings;
+    }
+
+    /**
+     * Calculates any line swaps that need to take place in order for the use
+     * statements to be organized.
+     *
+     * @return array hash of current line number to new line number
+     */
+    public function getLineSwaps()
+    {
+        $lineSwaps = [];
+        $currentLineNumbers = $this->useStatementsToLineNumbers($this->useStatements);
+        $organizedLineNumbers = $this->useStatementsToLineNumbers($this->organizedUseStatements);
+
+        // keep track of the swaps
+        $this->lineNumberMapping = [];
+        foreach ($currentLineNumbers as $currentLineNumber) {
+            $this->lineNumberMapping[$currentLineNumber] = $currentLineNumber;
+        }
+
+        // start from the bottom
+        for ($organizedIndex = count($organizedLineNumbers) - 1; $organizedIndex >= 0; $organizedIndex--) {
+            $currentLineNumber = $currentLineNumbers[$organizedIndex];
+            $organizedLineNumber = $organizedLineNumbers[$organizedIndex];
+            $newLineNumber = array_search($organizedLineNumber, $this->lineNumberMapping);
+
+            if ($currentLineNumber != $newLineNumber) {
+                $this->lineNumberMapping = $this->swap($this->lineNumberMapping, $currentLineNumber, $newLineNumber);
+
+                $lineSwaps[$currentLineNumber] = $newLineNumber;
+            }
+        }
+
+        return $lineSwaps;
+    }
+
+    /**
+     * @param UseStatement[] $useStatements
+     * @return array
+     */
+    private function useStatementsToLineNumbers(array $useStatements)
+    {
+        $useLines = [];
+
+        foreach ($useStatements as $useStatement) {
+            $useLines[] = $useStatement->getLine();
+        }
+
+        return $useLines;
+    }
+
+    /**
+     * @param array $arr
+     * @param mixed $currentKey
+     * @param mixed $newKey
+     * @return array
+     */
+    private function swap(array $arr, $currentKey, $newKey)
+    {
+        $currentValue = $arr[$currentKey];
+        $newValue = $arr[$newKey];
+
+        $arr[$currentKey] = $newValue;
+        $arr[$newKey] = $currentValue;
+
+        return $arr;
+    }
+
+    /**
+     * Returns a hash with key of the current line number and value of the line
+     * number it should be at.
+     *
+     * @return array
+     */
+    public function getLineNumberMapping()
+    {
+        if (!$this->lineNumberMapping) {
+            throw \BadMethodCallException("You must call getLineSwaps() before calling this function");
+        }
+
+        return $this->lineNumberMapping;
+    }
+}

--- a/src/test/bugfree/BugfreeTest.php
+++ b/src/test/bugfree/BugfreeTest.php
@@ -3,8 +3,8 @@
 namespace bugfree;
 
 
-use bugfree\config\Config;
 use Phake;
+use bugfree\config\Config;
 
 class BugfreeTest extends \PHPUnit_Framework_TestCase
 {
@@ -18,7 +18,10 @@ class BugfreeTest extends \PHPUnit_Framework_TestCase
         $this->resolver = Phake::mock(Resolver::_CLASS);
         Phake::when($this->resolver)->isValid(Phake::anyParameters())->thenReturn(true);
 
-        $this->bugfree = new Bugfree($this->resolver, new Config());
+        $config = new Config();
+        $config->emitLevel->{ErrorType::DISORGANIZED_USES} = ErrorType::SUPPRESS;
+
+        $this->bugfree = new Bugfree($this->resolver, $config);
     }
 
     private function assertArrayValuesContains(array $array, $string)

--- a/src/test/bugfree/fix/RemoveLineFixTest.php
+++ b/src/test/bugfree/fix/RemoveLineFixTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace bugfree\fix;
+
+class RemoveLineFixTest extends \PHPUnit_Framework_TestCase
+{
+    const LINE_1 = "line 1";
+    const LINE_2 = "line 2";
+    const LINE_3 = "line 3";
+    const LINE_4 = "line 4";
+    const LINE_5 = "line 5";
+
+    /** @var array */
+    private $fileLines;
+
+    public function setUp()
+    {
+        $this->fileLines = [
+            self::LINE_1,
+            self::LINE_2,
+            self::LINE_3,
+            self::LINE_4,
+            self::LINE_5
+        ];
+    }
+
+    public function testRemoveLine()
+    {
+        $fix = new RemoveLineFix(1, "");
+        $fix->run($this->fileLines);
+
+        $this->assertEquals(self::LINE_2, $this->fileLines[0]);
+    }
+
+    public function testMultipleRemoveLine()
+    {
+        $fix = new RemoveLineFix(1, "");
+        $fix->run($this->fileLines);
+        $fix = new RemoveLineFix(3, "");
+        $fix->run($this->fileLines);
+
+        $this->assertEquals(self::LINE_2, $this->fileLines[0]);
+        $this->assertEquals(self::LINE_3, $this->fileLines[1]);
+        $this->assertEquals(self::LINE_5, $this->fileLines[2]);
+    }
+}

--- a/src/test/bugfree/fix/SwapLineFixTest.php
+++ b/src/test/bugfree/fix/SwapLineFixTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace bugfree\fix;
+
+class SwapLineFixTest extends \PHPUnit_Framework_TestCase
+{
+    const LINE_1 = "line 1";
+    const LINE_2 = "line 2";
+    const LINE_3 = "line 3";
+    const LINE_4 = "line 4";
+    const LINE_5 = "line 5";
+
+    /** @var array */
+    private $fileLines;
+
+    public function setUp()
+    {
+        $this->fileLines = [
+            self::LINE_1,
+            self::LINE_2,
+            self::LINE_3,
+            self::LINE_4,
+            self::LINE_5
+        ];
+    }
+
+    public function testSwapLine()
+    {
+        $fix = new SwapLineFix(1, 2, "");
+        $fix->run($this->fileLines);
+
+        $this->assertEquals(self::LINE_2, $this->fileLines[0]);
+        $this->assertEquals(self::LINE_1, $this->fileLines[1]);
+    }
+
+    public function testMultipleSwapLines()
+    {
+        $fix = new SwapLineFix(5, 3, "");
+        $fix->run($this->fileLines);
+
+        $fix = new SwapLineFix(3, 1, "");
+        $fix->run($this->fileLines);
+
+        $this->assertEquals(self::LINE_5, $this->fileLines[0]);
+        $this->assertEquals(self::LINE_1, $this->fileLines[2]);
+        $this->assertEquals(self::LINE_3, $this->fileLines[4]);
+    }
+}

--- a/src/test/bugfree/helper/UseStatementOrganizerTest.php
+++ b/src/test/bugfree/helper/UseStatementOrganizerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace bugfree\helper;
+
+
+use Phake;
+
+class UseStatementOrganizerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNoUseStatements()
+    {
+        $useStatements = [];
+        $useStatementOrganizer = new UseStatementOrganizer($useStatements);
+
+        $this->assertTrue($useStatementOrganizer->areOrganized());
+    }
+
+    public function testOrganizedUseStatements()
+    {
+        $useStatements = [
+            $this->getMockUseStatement("a\b\c\AClass"),
+            $this->getMockUseStatement("a\b\c\BClass"),
+            $this->getMockUseStatement("a\b\c\BClass"),
+            $this->getMockUseStatement("a\b\c\d\AClass"),
+            $this->getMockUseStatement("a\b\c\d\BClass")
+        ];
+        $useStatementOrganizer = new UseStatementOrganizer($useStatements);
+
+        $this->assertTrue($useStatementOrganizer->areOrganized());
+    }
+
+    public function testUnorganizedUseStatements()
+    {
+        $useStatements = [
+            $this->getMockUseStatement("a\b\c\AClass"),
+            $this->getMockUseStatement("a\b\c\d\AClass"),
+            $this->getMockUseStatement("a\b\c\BClass"),
+            $this->getMockUseStatement("a\b\c\d\BClass")
+        ];
+        $useStatementOrganizer = new UseStatementOrganizer($useStatements);
+
+        $this->assertFalse($useStatementOrganizer->areOrganized());
+    }
+
+    public function testGetLineSwaps()
+    {
+        $useStatements = [
+            $this->getMockUseStatement("a\b\c\AClass", 3),
+            $this->getMockUseStatement("a\B\c\BClass", 4),
+            $this->getMockUseStatement("a\b\c\d\BClass", 6),
+            $this->getMockUseStatement("a\b\c\d\CClass", 9),
+            $this->getMockUseStatement("a\b\DClass", 11),
+            $this->getMockUseStatement("a\b\c\DClass", 13)
+        ];
+        $useStatementOrganizer = new UseStatementOrganizer($useStatements);
+        $lineSwaps = $useStatementOrganizer->getLineSwaps();
+
+        $this->assertEquals(4, count($lineSwaps));
+        $this->assertEquals(9, $lineSwaps[13]);
+        $this->assertEquals(6, $lineSwaps[11]);
+        $this->assertEquals(4, $lineSwaps[6]);
+        $this->assertEquals(3, $lineSwaps[4]);
+    }
+
+    public function testGetLineSwaps2()
+    {
+        $useStatements = [
+            $this->getMockUseStatement("a\b\AClass", 5),
+            $this->getMockUseStatement("a\b\BClass", 6),
+            $this->getMockUseStatement("a\b\CClass", 8),
+            $this->getMockUseStatement("a\b\DClass", 9),
+            $this->getMockUseStatement("a\b\c\d\DClass", 11),
+            $this->getMockUseStatement("a\b\c\d\CClass", 12),
+            $this->getMockUseStatement("a\b\EClass", 14),
+            $this->getMockUseStatement("a\b\c\AClass", 16),
+            $this->getMockUseStatement("a\b\c\BClass", 17)
+        ];
+        $useStatementOrganizer = new UseStatementOrganizer($useStatements);
+        $lineSwaps = $useStatementOrganizer->getLineSwaps();
+
+        $this->assertEquals(3, count($lineSwaps));
+        $this->assertEquals(11, $lineSwaps[17]);
+        $this->assertEquals(12, $lineSwaps[16]);
+        $this->assertEquals(11, $lineSwaps[14]);
+    }
+
+    private function getMockUseStatement($namepace, $line = 0)
+    {
+        $name = Phake::mock("PHPParser_Node_Name");
+        Phake::when($name)->__get("parts")->thenReturn(explode("\\", $namepace));
+        Phake::when($name)->toString()->thenReturn($namepace);
+
+        $useStatement = Phake::mock("PHPParser_Node_Stmt_UseUse");
+        Phake::when($useStatement)->__get("name")->thenReturn($name);
+        Phake::when($useStatement)->getLine()->thenReturn($line);
+
+        return $useStatement;
+    }
+}


### PR DESCRIPTION
Checks if use statements are organized.

a/b/c/Class comes before a/b/c/subpackage

Also includes an autofix that organizes them and can handle organizing and removing unused statements in the same run.
