### PR TITLE
Fix inconsistent organizing and autofixing

### DIFF
--- a/src/main/bugfree/cli/Lint.php
+++ b/src/main/bugfree/cli/Lint.php
@@ -171,17 +171,9 @@ class Lint extends Command
 
             if (count($result->getFixes()) > 0) {
                 $fixes = $result->getFixes();
-                // Sort them and apply them in reverse order.
-                /** @var $fixLines Fix[] */
-                $fixLines = [];
-                foreach ($fixes as $fix) {
-                    $fixLines[$fix->getLine()] = $fix;
-                }
-
-                krsort($fixLines);
 
                 $fileLines = preg_split('/\r|\r\n|\n/', $rawFileContents);
-                foreach ($fixLines as $fix) {
+                foreach ($fixes as $fix) {
                     $fix->run($fileLines);
                 }
 

--- a/src/test/bugfree/helper/UseStatementOrganizerTest.php
+++ b/src/test/bugfree/helper/UseStatementOrganizerTest.php
@@ -42,6 +42,30 @@ class UseStatementOrganizerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($useStatementOrganizer->areOrganized());
     }
 
+    public function testSameLastNamespacePartWithAlias()
+    {
+        $useStatements = [
+            $this->getMockUseStatement("a\b\c\AClass", 1),
+            $this->getMockUseStatement("a\b\c\aclass", 2, "awful"),
+            $this->getMockUseStatement("a\b\c\aclass", 3, "horrid")
+        ];
+        $useStatementOrganizer = new UseStatementOrganizer($useStatements);
+
+        $this->assertTrue($useStatementOrganizer->areOrganized());
+    }
+
+    public function testSameLastNamespacePartWithAliasNotSorted()
+    {
+        $useStatements = [
+            $this->getMockUseStatement("a\b\c\AClass", 1),
+            $this->getMockUseStatement("a\b\c\aclass", 2, "horrid"),
+            $this->getMockUseStatement("a\b\c\aclass", 3, "awful")
+        ];
+        $useStatementOrganizer = new UseStatementOrganizer($useStatements);
+
+        $this->assertFalse($useStatementOrganizer->areOrganized());
+    }
+
     public function testGetLineSwaps()
     {
         $useStatements = [
@@ -60,6 +84,17 @@ class UseStatementOrganizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(6, $lineSwaps[11]);
         $this->assertEquals(4, $lineSwaps[6]);
         $this->assertEquals(3, $lineSwaps[4]);
+
+        $mapping = [
+            3 => 4,
+            4 => 6,
+            6 => 11,
+            9 => 13,
+            11 => 3,
+            13 => 9
+        ];
+
+        $this->assertEquals($mapping, $useStatementOrganizer->getLineNumberMovements());
     }
 
     public function testGetLineSwaps2()
@@ -82,16 +117,47 @@ class UseStatementOrganizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(11, $lineSwaps[17]);
         $this->assertEquals(12, $lineSwaps[16]);
         $this->assertEquals(11, $lineSwaps[14]);
+
+        $mapping = [
+            5 => 5,
+            6 => 6,
+            8 => 8,
+            9 => 9,
+            11 => 17,
+            12 => 16,
+            14 => 11,
+            16 => 12,
+            17 => 14
+        ];
+
+        $this->assertEquals($mapping, $useStatementOrganizer->getLineNumberMovements());
     }
 
-    private function getMockUseStatement($namepace, $line = 0)
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testGetLineNumberMappingWithoutLineSwap()
     {
+        $useStatementOrganizer = new UseStatementOrganizer([]);
+        $useStatementOrganizer->getLineNumberMovements();
+    }
+
+    private function getMockUseStatement($namepace, $line = 0, $alias = null)
+    {
+        $parts = explode("\\", $namepace);
+        $lastPart = $parts[count($parts) - 1];
+
+        if (!$alias) {
+            $alias = $parts[count($parts) - 1];
+        }
+
         $name = Phake::mock("PHPParser_Node_Name");
-        Phake::when($name)->__get("parts")->thenReturn(explode("\\", $namepace));
+        Phake::when($name)->__get("parts")->thenReturn($parts);
         Phake::when($name)->toString()->thenReturn($namepace);
 
         $useStatement = Phake::mock("PHPParser_Node_Stmt_UseUse");
         Phake::when($useStatement)->__get("name")->thenReturn($name);
+        Phake::when($useStatement)->__get("alias")->thenReturn($alias);
         Phake::when($useStatement)->getLine()->thenReturn($line);
 
         return $useStatement;


### PR DESCRIPTION
If two namespaces end with the same string regardless of case their
aliases will be checked in order for organizing to be consistent.

If an unused use is to be organized, make sure the line swap occurs
and the removed line is correct.
