### PR TITLE
Handle classes with same name as typeFixes

### DIFF
--- a/src/main/bugfree/visitors/NameValidator.php
+++ b/src/main/bugfree/visitors/NameValidator.php
@@ -631,15 +631,19 @@ class NameValidator extends \PHPParser_NodeVisitorAbstract
             }
             if (!isset(self::$ignored_types[strtolower($typePart)])) {
                 $all_ok = true;
-                foreach ($typeFixes as $typo => $replacement) {
-                    if (strtolower($typePart) === $typo) {
-                        $all_ok = false;
-                        $reason = "$typo is not a valid type. Please see http://www.phpdoc.org/docs/latest/for-users/phpdoc/types.html for a list of valid types.";
+                $type = $this->nodeFromString($typePart, $line);
+                $qualifiedName = $this->getQualifiedName($type);
+                if (!$this->resolver->isValid($qualifiedName)) {
+                    foreach ($typeFixes as $typo => $replacement) {
+                        if (strtolower($typePart) === $typo) {
+                            $all_ok = false;
+                            $reason = "$typo is not a valid type. Please see http://www.phpdoc.org/docs/latest/for-users/phpdoc/types.html for a list of valid types.";
 
-                        if ($this->result->getConfig()->autoFix) {
-                            $this->result->fix(new StrReplaceFix($line, $reason, $typo, $replacement));
-                        } else {
-                            $this->result->error(ErrorType::COMMON_TYPOS, $line, $reason);
+                            if ($this->result->getConfig()->autoFix) {
+                                $this->result->fix(new StrReplaceFix($line, $reason, $typo, $replacement));
+                            } else {
+                                $this->result->error(ErrorType::COMMON_TYPOS, $line, $reason);
+                            }
                         }
                     }
                 }

--- a/src/test/bugfree/BugfreeTest.php
+++ b/src/test/bugfree/BugfreeTest.php
@@ -209,10 +209,6 @@ class BugfreeTest extends \PHPUnit_Framework_TestCase
             count($result->getErrors()),
             print_r($result->getErrors(), true)
         );
-
-        foreach ($options['invalid'] as $resolveCall) {
-            Phake::verify($this->resolver)->isValid($resolveCall);
-        }
     }
 
     /**
@@ -627,6 +623,22 @@ class BugfreeTest extends \PHPUnit_Framework_TestCase
         $src = "<?php namespace foo;
             /**
              * @param string|integer \$a ggg
+             */
+            function foo(\$a) {}
+        ";
+
+        $result = $this->bugfree->parse('test', $src, $this->resolver);
+
+        $this->assertEquals(0, count($result->getErrors()), print_r($result->getErrors(), true));
+    }
+
+    public function testClassNamePriorityOverPhpDocSuggestions()
+    {
+        Phake::when($this->resolver)->isValid("\\foo\\Amount")->thenReturn(true);
+
+        $src = "<?php namespace foo;
+            /**
+             * @param Amount \$a
              */
             function foo(\$a) {}
         ";


### PR DESCRIPTION
pretty hacky but resolveType() has too many side effects to reuse
